### PR TITLE
chore: remove npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,0 @@
-.editorconfig
-.eslintrc
-.github
-.tarvis.yml
-*.DS_Store
-*npm-debug.log
-*yarn-error.log
-screenshots/
-tests/


### PR DESCRIPTION
as we already have the 'files' key in our package.json, there's no need
to keep a npmignore file, which is actually more trouble to maintain