### PR TITLE
bin: add robrowser config as js file

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const { join } = require('path')
-const { readFileSync } = require('fs')
+const { readFileSync, existsSync } = require('fs')
 const { rootPath } = require('get-root-path')
 const browserstack = require('browserstack-local')
 const {
@@ -98,8 +98,20 @@ const run = () => {
     robrowserConfigPath = './.robrowser'
   }
 
-  const configsPath = join(rootPath, robrowserConfigPath)
-  const config = loadJSON(configsPath)
+  const configFiles = [
+    {
+      file: join(rootPath, 'robrowser.config.js'),
+      fn: require,
+    },
+    {
+      file: join(rootPath, robrowserConfigPath),
+      fn: loadJSON,
+    },
+  ]
+
+  const { file, fn } = configFiles.find(item => existsSync(item.file))
+
+  const config = fn(file)
 
   const { concurrency = 1, browsers } = config
 

--- a/examples/robrowser.config.js
+++ b/examples/robrowser.config.js
@@ -1,0 +1,32 @@
+module.exports = {
+  remote: {
+    host: 'hub.browserstack.com',
+    port: 80,
+    user: 'YOUR_USERNAME_HERE',
+    pwd: 'YOUR_ACCESS_KEY_HERE',
+  },
+  screenshot: {
+    folder: './screenshots',
+  },
+  browsers: [
+    {
+      os: 'windows',
+      os_version: '7',
+      browserName: 'chrome',
+      browser_version: '55',
+      resolution: '1920x1080',
+      url: 'http://google.com',
+      test: './examples/index.des.js',
+    },
+    {
+      browserName: 'android',
+      device: 'Google Nexus 9',
+      realMobile: true,
+      os_version: '5.1',
+      deviceOrientation: 'portrait',
+      url: 'http://google.com',
+      test: './examples/index.mob.js',
+    },
+  ],
+  concurrency: 2,
+}


### PR DESCRIPTION
This PR adds the ability to use `robrowser.config.js` instead of `.robrowser` file.